### PR TITLE
Respect the interface in PhpDocAuthorExtractor

### DIFF
--- a/src/AuthorExtractor/PhpDocAuthorExtractor.php
+++ b/src/AuthorExtractor/PhpDocAuthorExtractor.php
@@ -70,7 +70,7 @@ class PhpDocAuthorExtractor extends AbstractPatchingAuthorExtractor
         $content = file_get_contents($path, null, null, null, 4096);
         $closing = strpos($content, '*/');
         if ($closing === false) {
-            return array();
+            return '';
         }
 
         $tokens    = token_get_all(substr($content, 0, ($closing + 2)));


### PR DESCRIPTION
If no doc block isset, the extractor throws a warning because an array is returned instead of a string.
This PR fixes it interface and returns string.

Lines 77-83 are useless in this extractor at the moment. That's the aim for it? Leftover or not ready implemented freature?
