### PR TITLE
Provide feature to add project authors to a file.

### DIFF
--- a/.check-author.yml
+++ b/.check-author.yml
@@ -1,3 +1,8 @@
+mapping:
+  David Molineus <david.molineus@netzmacht.de>:
+    - David Molineus <david.molineus@netzmacht.de>
+    - David Molineus <mail@netzmacht.de>
+
 copy-left:
   Jordi Boggiano <j.boggiano@seld.be>: JsonFormatter.php
   Konstantin Kudryashiv <ever.zet@gmail.com>: JsonFormatter.php

--- a/src/AuthorExtractor/AbstractGitAuthorAuthorExtractor.php
+++ b/src/AuthorExtractor/AbstractGitAuthorAuthorExtractor.php
@@ -29,7 +29,7 @@ use Symfony\Component\Process\ProcessBuilder;
 /**
  * Base class for author extraction from a git repository.
  */
-abstract class AbstractGitExtractor extends AbstractAuthorExtractor
+abstract class AbstractGitAuthorExtractor extends AbstractAuthorExtractor
 {
     /**
      * Create a git repository instance.

--- a/src/AuthorExtractor/AbstractGitAuthorExtractor.php
+++ b/src/AuthorExtractor/AbstractGitAuthorExtractor.php
@@ -12,6 +12,7 @@
  *
  * @package    contao-community-alliance/build-system-tool-author-validation
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  Contao Community Alliance <https://c-c-a.org>
  * @link       https://github.com/contao-community-alliance/build-system-tool-author-validation
  * @license    https://github.com/contao-community-alliance/build-system-tool-author-validation/blob/master/LICENSE MIT

--- a/src/AuthorExtractor/AbstractGitAuthorExtractor.php
+++ b/src/AuthorExtractor/AbstractGitAuthorExtractor.php
@@ -1,0 +1,184 @@
+<?php
+
+/**
+ * This file is part of contao-community-alliance/build-system-tool-author-validation.
+ *
+ * (c) Contao Community Alliance <https://c-c-a.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    contao-community-alliance/build-system-tool-author-validation
+ * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @copyright  Contao Community Alliance <https://c-c-a.org>
+ * @link       https://github.com/contao-community-alliance/build-system-tool-author-validation
+ * @license    https://github.com/contao-community-alliance/build-system-tool-author-validation/blob/master/LICENSE MIT
+ * @filesource
+ */
+
+namespace ContaoCommunityAlliance\BuildSystem\Tool\AuthorValidation\AuthorExtractor;
+
+use ContaoCommunityAlliance\BuildSystem\Repository\GitException;
+use ContaoCommunityAlliance\BuildSystem\Repository\GitRepository;
+use Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\ProcessBuilder;
+
+/**
+ * Base class for author extraction from a git repository.
+ */
+abstract class AbstractGitExtractor extends AbstractAuthorExtractor
+{
+    /**
+     * Create a git repository instance.
+     *
+     * @param string $path A path within a git repository.
+     *
+     * @return GitRepository.
+     */
+    protected function getGitRepositoryFor($path)
+    {
+        $git = new GitRepository($this->determineGitRoot($path));
+        if ($this->output->getVerbosity() >= OutputInterface::VERBOSITY_DEBUG) {
+            $git->getConfig()->setLogger(
+                new ConsoleLogger($this->output)
+            );
+        }
+
+        return $git;
+    }
+
+    /**
+     * Retrieve a list of all files within a git repository.
+     *
+     * @param GitRepository $git The repository to extract all files from.
+     *
+     * @return string[]
+     *
+     * @throws GitException When the git execution failed.
+     */
+    protected function getAllFilesFromGit($git)
+    {
+        $gitDir = $git->getRepositoryPath();
+        // Sadly no command in our git library for this.
+        $processBuilder = new ProcessBuilder();
+        $processBuilder->setWorkingDirectory($gitDir);
+        $processBuilder
+            ->add($git->getConfig()->getGitExecutablePath())
+            ->add('ls-tree')
+            ->add('HEAD')
+            ->add('-r')
+            ->add('--full-name')
+            ->add('--name-only');
+
+        $process = $processBuilder->getProcess();
+
+        $git->getConfig()->getLogger()->debug(
+            sprintf('[ccabs-repository-git] exec [%s] %s', $process->getWorkingDirectory(), $process->getCommandLine())
+        );
+
+        $process->run();
+        $output = rtrim($process->getOutput(), "\r\n");
+
+        if (!$process->isSuccessful()) {
+            throw GitException::createFromProcess('Could not execute git command', $process);
+        }
+
+        $files = array();
+        foreach (explode(PHP_EOL, $output) as $file) {
+            $absolutePath = $gitDir . '/' . $file;
+            if (!$this->config->isPathExcluded($absolutePath)) {
+                $files[trim($absolutePath)] = trim($absolutePath);
+            }
+        }
+
+        return $files;
+    }
+
+    /**
+     * Retrieve the file path to use in reporting.
+     *
+     * @return string
+     */
+    public function getFilePaths()
+    {
+        $files = array();
+        foreach ($this->config->getIncludedPaths() as $path) {
+            $files = array_merge($files, $this->getAllFilesFromGit($this->getGitRepositoryFor($path)));
+        }
+
+        return $files;
+    }
+
+    /**
+     * Determine the git root, starting from arbitrary directory.
+     *
+     * @param string $path The start path.
+     *
+     * @return string The git root path.
+     *
+     * @throws \RuntimeException If the git root could not determined.
+     */
+    private function determineGitRoot($path)
+    {
+        // @codingStandardsIgnoreStart
+        while (strlen($path) > 1) {
+            // @codingStandardsIgnoreEnd
+            if (is_dir($path . DIRECTORY_SEPARATOR . '.git')) {
+                return $path;
+            }
+
+            $path = dirname($path);
+        }
+
+        throw new \RuntimeException('Could not determine git root, starting from ' . func_get_arg(0));
+    }
+
+    /**
+     * Retrieve the data of the current user on the system.
+     *
+     * @param GitRepository $git The repository to extract all files from.
+     *
+     * @return string
+     *
+     * @throws GitException When the git execution failed.
+     */
+    protected function getCurrentUserInfo($git)
+    {
+        // Sadly no command in our git library for this.
+        $processBuilder = new ProcessBuilder();
+        $processBuilder->setWorkingDirectory($git->getRepositoryPath());
+        $processBuilder
+            ->add($git->getConfig()->getGitExecutablePath())
+            ->add('config')
+            ->add('--get-regexp')
+            ->add('user.[name|email]');
+
+        $process = $processBuilder->getProcess();
+
+        $git->getConfig()->getLogger()->debug(
+            sprintf('[ccabs-repository-git] exec [%s] %s', $process->getWorkingDirectory(), $process->getCommandLine())
+        );
+
+        $process->run();
+        $output = rtrim($process->getOutput(), "\r\n");
+
+        if (!$process->isSuccessful()) {
+            throw GitException::createFromProcess('Could not execute git command', $process);
+        }
+
+        $config = array();
+        foreach (explode(PHP_EOL, $output) as $line) {
+            list($name, $value)  = explode(' ', $line, 2);
+            $config[trim($name)] = trim($value);
+        }
+
+        if (isset($config['user.name']) && $config['user.email']) {
+            return sprintf('%s <%s>', $config['user.name'], $config['user.email']);
+        }
+
+        return '';
+    }
+}

--- a/src/AuthorExtractor/AbstractGitAuthorExtractor.php
+++ b/src/AuthorExtractor/AbstractGitAuthorExtractor.php
@@ -59,7 +59,7 @@ abstract class AbstractGitAuthorExtractor extends AbstractAuthorExtractor
      *
      * @throws GitException When the git execution failed.
      */
-    protected function getAllFilesFromGit($git)
+    private function getAllFilesFromGit($git)
     {
         $gitDir = $git->getRepositoryPath();
         // Sadly no command in our git library for this.

--- a/src/AuthorExtractor/GitAuthorExtractor.php
+++ b/src/AuthorExtractor/GitAuthorExtractor.php
@@ -12,6 +12,7 @@
  *
  * @package    contao-community-alliance/build-system-tool-author-validation
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  Contao Community Alliance <https://c-c-a.org>
  * @link       https://github.com/contao-community-alliance/build-system-tool-author-validation
  * @license    https://github.com/contao-community-alliance/build-system-tool-author-validation/blob/master/LICENSE MIT

--- a/src/AuthorExtractor/GitAuthorExtractor.php
+++ b/src/AuthorExtractor/GitAuthorExtractor.php
@@ -26,7 +26,7 @@ use Symfony\Component\Finder\Finder;
 /**
  * Extract the author information from a git repository.
  */
-class GitAuthorExtractor extends AbstractGitExtractor
+class GitAuthorExtractor extends AbstractGitAuthorExtractor
 {
     /**
      * Optional attached finder for processing multiple files.

--- a/src/AuthorExtractor/GitAuthorExtractor.php
+++ b/src/AuthorExtractor/GitAuthorExtractor.php
@@ -20,17 +20,13 @@
 
 namespace ContaoCommunityAlliance\BuildSystem\Tool\AuthorValidation\AuthorExtractor;
 
-use ContaoCommunityAlliance\BuildSystem\Repository\GitException;
 use ContaoCommunityAlliance\BuildSystem\Repository\GitRepository;
-use Symfony\Component\Console\Logger\ConsoleLogger;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\Process\ProcessBuilder;
 
 /**
  * Extract the author information from a git repository.
  */
-class GitAuthorExtractor extends AbstractAuthorExtractor
+class GitAuthorExtractor extends AbstractGitExtractor
 {
     /**
      * Optional attached finder for processing multiple files.
@@ -38,96 +34,6 @@ class GitAuthorExtractor extends AbstractAuthorExtractor
      * @var Finder
      */
     protected $finder;
-
-    /**
-     * Create a git repository instance.
-     *
-     * @param string $path A path within a git repository.
-     *
-     * @return GitRepository.
-     */
-    private function getGitRepositoryFor($path)
-    {
-        $git = new GitRepository($this->determineGitRoot($path));
-        if ($this->output->getVerbosity() >= OutputInterface::VERBOSITY_DEBUG) {
-            $git->getConfig()->setLogger(
-                new ConsoleLogger($this->output)
-            );
-        }
-
-        return $git;
-    }
-
-    /**
-     * Determine the git root, starting from arbitrary directory.
-     *
-     * @param string $path The start path.
-     *
-     * @return string The git root path.
-     *
-     * @throws \RuntimeException If the git root could not determined.
-     */
-    private function determineGitRoot($path)
-    {
-        // @codingStandardsIgnoreStart
-        while (strlen($path) > 1) {
-            // @codingStandardsIgnoreEnd
-            if (is_dir($path . DIRECTORY_SEPARATOR . '.git')) {
-                return $path;
-            }
-
-            $path = dirname($path);
-        }
-
-        throw new \RuntimeException('Could not determine git root, starting from ' . func_get_arg(0));
-    }
-
-    /**
-     * Retrieve a list of all files within a git repository.
-     *
-     * @param GitRepository $git The repository to extract all files from.
-     *
-     * @return string[]
-     *
-     * @throws GitException When the git execution failed.
-     */
-    private function getAllFilesFromGit($git)
-    {
-        $gitDir = $git->getRepositoryPath();
-        // Sadly no command in our git library for this.
-        $processBuilder = new ProcessBuilder();
-        $processBuilder->setWorkingDirectory($gitDir);
-        $processBuilder
-            ->add($git->getConfig()->getGitExecutablePath())
-            ->add('ls-tree')
-            ->add('HEAD')
-            ->add('-r')
-            ->add('--full-name')
-            ->add('--name-only');
-
-        $process = $processBuilder->getProcess();
-
-        $git->getConfig()->getLogger()->debug(
-            sprintf('[ccabs-repository-git] exec [%s] %s', $process->getWorkingDirectory(), $process->getCommandLine())
-        );
-
-        $process->run();
-        $output = rtrim($process->getOutput(), "\r\n");
-
-        if (!$process->isSuccessful()) {
-            throw GitException::createFromProcess('Could not execute git command', $process);
-        }
-
-        $files = array();
-        foreach (explode(PHP_EOL, $output) as $file) {
-            $absolutePath = $gitDir . '/' . $file;
-            if (!$this->config->isPathExcluded($absolutePath)) {
-                $files[trim($absolutePath)] = trim($absolutePath);
-            }
-        }
-
-        return $files;
-    }
 
     /**
      * Convert the git binary output to a valid author list.
@@ -142,21 +48,6 @@ class GitAuthorExtractor extends AbstractAuthorExtractor
             return array();
         }
         return preg_split('~[\r\n]+~', $authors);
-    }
-
-    /**
-     * Retrieve the file path to use in reporting.
-     *
-     * @return string
-     */
-    public function getFilePaths()
-    {
-        $files = array();
-        foreach ($this->config->getIncludedPaths() as $path) {
-            $files = array_merge($files, $this->getAllFilesFromGit($this->getGitRepositoryFor($path)));
-        }
-
-        return $files;
     }
 
     /**
@@ -196,52 +87,6 @@ class GitAuthorExtractor extends AbstractAuthorExtractor
     private function getAuthorListFrom($path, $git)
     {
         return $git->log()->format('%aN <%ae>')->follow()->execute($path);
-    }
-
-    /**
-     * Retrieve the data of the current user on the system.
-     *
-     * @param GitRepository $git The repository to extract all files from.
-     *
-     * @return string
-     *
-     * @throws GitException When the git execution failed.
-     */
-    private function getCurrentUserInfo($git)
-    {
-        // Sadly no command in our git library for this.
-        $processBuilder = new ProcessBuilder();
-        $processBuilder->setWorkingDirectory($git->getRepositoryPath());
-        $processBuilder
-            ->add($git->getConfig()->getGitExecutablePath())
-            ->add('config')
-            ->add('--get-regexp')
-            ->add('user.[name|email]');
-
-        $process = $processBuilder->getProcess();
-
-        $git->getConfig()->getLogger()->debug(
-            sprintf('[ccabs-repository-git] exec [%s] %s', $process->getWorkingDirectory(), $process->getCommandLine())
-        );
-
-        $process->run();
-        $output = rtrim($process->getOutput(), "\r\n");
-
-        if (!$process->isSuccessful()) {
-            throw GitException::createFromProcess('Could not execute git command', $process);
-        }
-
-        $config = array();
-        foreach (explode(PHP_EOL, $output) as $line) {
-            list($name, $value)  = explode(' ', $line, 2);
-            $config[trim($name)] = trim($value);
-        }
-
-        if (isset($config['user.name']) && $config['user.email']) {
-            return sprintf('%s <%s>', $config['user.name'], $config['user.email']);
-        }
-
-        return '';
     }
 
     /**

--- a/src/AuthorExtractor/GitProjectAuthorExtractor.php
+++ b/src/AuthorExtractor/GitProjectAuthorExtractor.php
@@ -67,7 +67,7 @@ class GitProjectAuthorExtractor extends AbstractGitAuthorExtractor
      */
     private function hasUncommittedChanges($git)
     {
-        $status  = $git->status()->short()->getIndexStatus();
+        $status = $git->status()->short()->getIndexStatus();
 
         if (empty($status)) {
             return false;

--- a/src/AuthorExtractor/GitProjectAuthorExtractor.php
+++ b/src/AuthorExtractor/GitProjectAuthorExtractor.php
@@ -12,6 +12,7 @@
  *
  * @package    contao-community-alliance/build-system-tool-author-validation
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  Contao Community Alliance <https://c-c-a.org>
  * @link       https://github.com/contao-community-alliance/build-system-tool-author-validation
  * @license    https://github.com/contao-community-alliance/build-system-tool-author-validation/blob/master/LICENSE MIT

--- a/src/AuthorExtractor/GitProjectAuthorExtractor.php
+++ b/src/AuthorExtractor/GitProjectAuthorExtractor.php
@@ -84,7 +84,7 @@ class GitProjectAuthorExtractor extends AbstractGitAuthorExtractor
      */
     private function getAuthorListFrom($git)
     {
-        return $git->shortlog()->summary()->email()->execute();
+        return $git->shortlog()->summary()->email()->revisionRange('HEAD')->execute();
     }
 
     /**

--- a/src/AuthorExtractor/GitProjectAuthorExtractor.php
+++ b/src/AuthorExtractor/GitProjectAuthorExtractor.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * This file is part of contao-community-alliance/build-system-tool-author-validation.
+ *
+ * (c) Contao Community Alliance <https://c-c-a.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * This project is provided in good faith and hope to be usable by anyone.
+ *
+ * @package    contao-community-alliance/build-system-tool-author-validation
+ * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @copyright  Contao Community Alliance <https://c-c-a.org>
+ * @link       https://github.com/contao-community-alliance/build-system-tool-author-validation
+ * @license    https://github.com/contao-community-alliance/build-system-tool-author-validation/blob/master/LICENSE MIT
+ * @filesource
+ */
+
+namespace ContaoCommunityAlliance\BuildSystem\Tool\AuthorValidation\AuthorExtractor;
+
+use ContaoCommunityAlliance\BuildSystem\Repository\GitRepository;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Extract the author information from a git repository. It does not care about which file where changed.
+ */
+class GitProjectAuthorExtractor extends AbstractGitAuthorExtractor
+{
+    /**
+     * Optional attached finder for processing multiple files.
+     *
+     * @var Finder
+     */
+    protected $finder;
+
+    /**
+     * Convert the git binary output to a valid author list.
+     *
+     * @param string[] $authors The author list to convert.
+     *
+     * @return string[]
+     */
+    private function convertAuthorList($authors)
+    {
+        if (!$authors) {
+            return array();
+        }
+
+        // remove commit sumary of author list
+        return array_map(
+            function ($author) {
+                return preg_replace('~\s*([0-9]+)\s+(.*)~', '$2', $author);
+            },
+            preg_split('~[\r\n]+~', $authors)
+        );
+    }
+
+    /**
+     * Check if git repository has uncommitted modifications.
+     *
+     * @param GitRepository $git  The repository to extract all files from.
+     *
+     * @return bool
+     */
+    private function hasUncommittedChanges($git)
+    {
+        $status  = $git->status()->short()->getIndexStatus();
+
+        if (empty($status)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Retrieve the author list from the git repository via calling git.
+     *
+     * @param GitRepository $git The repository to extract all files from.
+     *
+     * @return string[]
+     */
+    private function getAuthorListFrom($git)
+    {
+        return $git->shortlog()->summary()->email()->execute();
+    }
+
+    /**
+     * Perform the extraction of authors.
+     *
+     * @param string $path A path obtained via a prior call to AuthorExtractor::getFilePaths().
+     *
+     * @return string[]|null
+     */
+    protected function doExtract($path)
+    {
+        $git = $this->getGitRepositoryFor($path);
+
+        $authors = $this->convertAuthorList($this->getAuthorListFrom($git));
+
+        // Check if repository has uncomitted changes, so that someone is currently working on it.
+        if ($this->hasUncommittedChanges($git)) {
+            $authors[] = $this->getCurrentUserInfo($git);
+        }
+
+        return $authors;
+    }
+}

--- a/src/Command/CheckAuthor.php
+++ b/src/Command/CheckAuthor.php
@@ -13,6 +13,7 @@
  * @package    contao-community-alliance/build-system-tool-author-validation
  * @author     Tristan Lins <tristan.lins@bit3.de>
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
+ * @author     David Molineus <david.molineus@netzmacht.de>
  * @copyright  Contao Community Alliance <https://c-c-a.org>
  * @link       https://github.com/contao-community-alliance/build-system-tool-author-validation
  * @license    https://github.com/contao-community-alliance/build-system-tool-author-validation/blob/master/LICENSE MIT

--- a/src/Command/CheckAuthor.php
+++ b/src/Command/CheckAuthor.php
@@ -75,7 +75,7 @@ class CheckAuthor extends Command
                 '--config',
                 '-f',
                 InputOption::VALUE_NONE,
-                'Validate authors in packages.json.'
+                'Optional config file path.'
             )
             ->addOption(
                 'ignore',

--- a/src/Command/CheckAuthor.php
+++ b/src/Command/CheckAuthor.php
@@ -97,6 +97,13 @@ class CheckAuthor extends Command
                 InputOption::VALUE_NONE,
                 'Create output in diff format instead of mentioning what\'s missing/superfluous.'
             )
+            ->addOption(
+                'scope',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Determine if file should contain authors of the file or the project',
+                'file'
+            )
             ->addArgument(
                 'include',
                 (InputArgument::IS_ARRAY | InputArgument::OPTIONAL),
@@ -202,7 +209,7 @@ class CheckAuthor extends Command
 
         $diff         = $input->getOption('diff');
         $extractors   = $this->createSourceExtractors($input, $error, $config);
-        $gitExtractor = new GitAuthorExtractor($config, $error);
+        $gitExtractor = $this->createGitAuthorExtractor($input->getOption('scope'), $config, $error);
         $comparator   = new AuthorListComparator($config, $error);
         $comparator->shallGeneratePatches($diff);
 
@@ -213,5 +220,23 @@ class CheckAuthor extends Command
         }
 
         return $failed ? 1 : 0;
+    }
+
+    /**
+     * Create git author extractor for demanded scope.
+     *
+     * @param string          $scope  Git author scope.
+     * @param Config          $config Author extractor config.
+     * @param OutputInterface $error  Error output.
+     *
+     * @return GitAuthorExtractor|AuthorExtractor\GitProjectAuthorExtractor
+     */
+    private function createGitAuthorExtractor($scope, Config $config, $error)
+    {
+        if ($scope === 'project') {
+            return new AuthorExtractor\GitProjectAuthorExtractor($config, $error);
+        } else {
+            return new GitAuthorExtractor($config, $error);
+        }
     }
 }


### PR DESCRIPTION
I've lately added the author-validation to my build tools. One thing I really miss is that only the files authors are recognized.

For the package files (e.g. `composer.json`) it would be great if all project authors are listed instead.

This pull request provides a new `scope` option to the command to switch to the project scope. Then the authors are compared to the project authors fetched from the git repository.

This pull request depends on https://github.com/contao-community-alliance/build-system-repository-git/pull/1