### PR TITLE
Support author metadata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,4 +70,12 @@ copy-left:
   # or
   "John Doe <jd@example.org>":
     - "File.php"
+    
+# Add additional author metadata. It is used by some comparator handlers when outputting diff format.
+# Author metadata of the config file is prioritized over extracted metadata from the files.
+
+metadata:
+  "John Doe <jd@example.org>":
+    role:     "Translator"
+    homepage: "http:/www.example.org"
 ```

--- a/src/AuthorExtractor/ComposerAuthorExtractor.php
+++ b/src/AuthorExtractor/ComposerAuthorExtractor.php
@@ -48,14 +48,25 @@ class ComposerAuthorExtractor extends JsonAuthorExtractor
             return array();
         }
 
+        $config           = $this->config;
         $mentionedAuthors = array_map(
-            function ($author) {
+            function ($author) use ($config) {
                 if (isset($author['email'])) {
-                    return sprintf(
+                    $author['name'] = sprintf(
                         '%s <%s>',
                         $author['name'],
                         $author['email']
                     );
+                }
+
+                // set role metadata if not already set.
+                if (isset($author['role']) && !$config->hasMetadata($author['name'], 'role')) {
+                    $config->setMetadata($author['name'], 'role', $author['role']);
+                }
+
+                // set homepage metadata if not already set.
+                if (isset($author['homepage']) && !$config->hasMetadata($author['name'], 'homepage')) {
+                    $config->setMetadata($author['name'], 'homepage', $author['homepage']);
                 }
 
                 return $author['name'];
@@ -81,11 +92,17 @@ class ComposerAuthorExtractor extends JsonAuthorExtractor
         foreach ($authors as $author) {
             list($name, $email) = explode(' <', $author);
 
-            $json['authors'][] = array(
+            $config = array(
                 'name'     => trim($name),
                 'email'    => trim(substr($email, 0, -1)),
-                'role'     => 'Developer'
+                'role'     => $this->config->getMetadata($author, 'role') ?: 'Developer'
             );
+
+            if ($this->config->hasMetadata($author, 'homepage')) {
+                $config['homepage'] = $this->config->getMetadata($author, 'homepage');
+            }
+
+            $json['authors'][] = $config;
         }
 
         return $json;

--- a/src/AuthorExtractor/ComposerAuthorExtractor.php
+++ b/src/AuthorExtractor/ComposerAuthorExtractor.php
@@ -94,13 +94,14 @@ class ComposerAuthorExtractor extends JsonAuthorExtractor
 
             $config = array(
                 'name'     => trim($name),
-                'email'    => trim(substr($email, 0, -1)),
-                'role'     => $this->config->getMetadata($author, 'role') ?: 'Developer'
+                'email'    => trim(substr($email, 0, -1))
             );
 
             if ($this->config->hasMetadata($author, 'homepage')) {
                 $config['homepage'] = $this->config->getMetadata($author, 'homepage');
             }
+
+            $config['role'] = $this->config->getMetadata($author, 'role') ?: 'Developer';
 
             $json['authors'][] = $config;
         }

--- a/src/Config.php
+++ b/src/Config.php
@@ -69,6 +69,16 @@ class Config
     protected $exclude = array();
 
     /**
+     * Author metadata.
+     *
+     * Format
+     *   Author: [ 'name' => 'value', .. ]
+     *
+     * @var array
+     */
+    protected $metadata = array();
+
+    /**
      * Create a new instance.
      *
      * @param string|bool $configFileName The config file to use.
@@ -169,6 +179,10 @@ class Config
 
         if (isset($config['exclude'])) {
             $this->excludePaths($config['exclude']);
+        }
+
+        if (isset($config['metadata'])) {
+            $this->addAuthorsMetadata($config['metadata']);
         }
 
         return $this;
@@ -456,5 +470,76 @@ class Config
     public function getExcludedPaths()
     {
         return array_values($this->exclude);
+    }
+
+    /**
+     * Add authors metadata.
+     *
+     * Format:
+     *   Author: [ name => value, ..]
+     *
+     * @param array $metadata Authors metadata.
+     *
+     * @return Config
+     */
+    public function addAuthorsMetadata($metadata)
+    {
+        foreach ($metadata as $author => $data) {
+            foreach ($data as $name => $value) {
+                $this->setMetadata($author, $name, $value);
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Check if a specific author metadata is defined.
+     *
+     * @param string $author The author.
+     * @param string $name   Metadata name.
+     *
+     * @return bool
+     */
+    public function hasMetadata($author, $name)
+    {
+        return isset($this->metadata[$this->arrayKey($author)][$name]);
+    }
+
+    /**
+     * Get a specific meta data for an author.
+     *
+     * It returns null if it is not set.
+     *
+     * @param string $author The author.
+     * @param string $name   Metadata name.
+     *
+     * @return mixed
+     */
+    public function getMetadata($author, $name)
+    {
+        $author = $this->arrayKey($author);
+
+        if (isset($this->metadata[$author][$name])) {
+            return $this->metadata[$author][$name];
+        }
+
+        return null;
+    }
+
+    /**
+     * set a specific meta data for an author.
+     *
+     * @param string $author The author.
+     * @param string $name   Metadata name.
+     * @param mixed  $value  Metadata value.
+     *
+     * @return Config
+     */
+    public function setMetadata($author, $name, $value)
+    {
+        $this->metadata[$this->arrayKey($author)][$name] = $value;
+
+        return $this;
     }
 }


### PR DESCRIPTION
At the moment defined author metadata (role, homepage, ...) are ignored and a patch would throw them away. 

This pull request adds the metadata to the config. It extracts them from the `composer.json` as well and would add them in the patch diff again.

Each extractor is responsible for it own to know which metadata is supported.